### PR TITLE
Bug fixes and clean-up

### DIFF
--- a/common/crypto.c
+++ b/common/crypto.c
@@ -66,7 +66,7 @@ void calc_sha256(uint8_t *p_msg, uint32_t len, uint32_t *p_sha) {
     uint32_t byte_n;
     uint8_t *p_new = NULL;
     // first 32 bits of the fractional parts of the cube roots of the first 64 primes
-	const static uint32_t K[64] = {
+    const static uint32_t K[64] = {
         0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
         0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
         0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
@@ -123,7 +123,7 @@ void calc_sha256(uint8_t *p_msg, uint32_t len, uint32_t *p_sha) {
     p_m_block = (struct m_block_t *)(void *)&p_new[0];
 
     /* step 3: --- calculate hash --- */
-    N = byte_n / 64; 
+    N = byte_n / 64;
     for (i = 0; i < N; i++) {
         uint32_t a, b, c, d, e, f, g, h;
 
@@ -191,26 +191,26 @@ void calc_sha256(uint8_t *p_msg, uint32_t len, uint32_t *p_sha) {
 uint32_t calc_crc32(const char *src, uint32_t sz)
 {
     char ch;
-	uint32_t crc = ~0;
-	uint32_t i = 0;
+    uint32_t crc = ~0;
+    uint32_t i = 0;
     uint32_t j = 0;
     uint32_t b = 0;
-	
+
     printf("crc = 0x%x\n", crc);
-	for(i = 0; i < sz; i++) {
-		ch = src[i];
-		for(j = 0; j < 8; j++) {
-			b = (ch ^ crc) & 1;
-			crc >>= 1;
-			if (b) {
+    for(i = 0; i < sz; i++) {
+        ch = src[i];
+        for(j = 0; j < 8; j++) {
+            b = (ch ^ crc) & 1;
+            crc >>= 1;
+            if (b) {
                 crc=crc^0xEDB88320;
             }
-			ch >>= 1;
-		}
-	}
+            ch >>= 1;
+        }
+    }
 
     printf("crc = %x\n", ~crc);
-	return ~crc;
+    return ~crc;
 }
 #if TEST_MAIN
 static uint8_t huge_a[1000000];

--- a/flash/README
+++ b/flash/README
@@ -62,6 +62,6 @@ board into recovery mode. The internally flashing process is as follows:
     Send the sequence of 0x5555555...like shake hands
     read response
 12./ If the response from step 11 indicates 'O''K', the flash is completed
-successfully.    
+successfully.
 
 If any response indicates the error, it should abort the flashing.

--- a/flash/comm.h
+++ b/flash/comm.h
@@ -23,8 +23,10 @@
 
 #include "packet_comm.h"
 
-/*XXX: move read_to_buf out of common.* */
+/*XXX: move read_to_buf and dump_hex  out of common.* */
 int read_to_buf(char *p_file_name, uint8_t **p_buf, uint32_t *p_sz_data);
+
+void dump_hex(const char *prefix, uint8_t *p_data, uint32_t len);
 
 int hand_shake(int uart_fd, uint32_t baud_rate);
 
@@ -52,7 +54,7 @@ int flash_data(int uart_fd, uint8_t *data, uint32_t len_data, uint32_t target_ad
 
 int notify_flash_done(int uart_fd);
 
-int send_sha256(int uart_fd, uint32_t *sha256);
+int send_sha256(int uart_fd, uint32_t *sha256, uint32_t start_addr, uint32_t len);
 
 int send_finish(int uart_fd);
 

--- a/flash/flash.c
+++ b/flash/flash.c
@@ -37,7 +37,7 @@ void print_help(const char *p_app_name)
     printf("USAGE: %s --uart uart_device --rate baud_rate --partition part1.bin part2.bin"
             "  --fw firmware.bin --dtb ro_param.dtb --eflash eflash_loader"
             "  --boot2 boot2image.bin\n", p_app_name);
-	return;
+    return;
 }
 
 /*
@@ -48,13 +48,13 @@ void print_help(const char *p_app_name)
  */
 int main(int argc, char *argv[])
 {
-	int ret_code;
+    int ret_code;
     int uart_fd = -1;
-	uint32_t baud_rate;
+    uint32_t baud_rate;
     boot_info_t boot_info;
     int i = 1;
     int j = 0;
-	char *p_uart_port;
+    char *p_uart_port;
     char *fw_file = NULL;
     char *dtb_file = NULL;
     char *boot2_file = NULL;
@@ -78,11 +78,11 @@ int main(int argc, char *argv[])
         {0x0000, NULL}, /* partition_3 */
     };
 
-	if (argc < 11) {
+    if (argc < 11) {
         fprintf(stderr, "ERROR: missing operand\n");
-		print_help(argv[0]);
-		return -1;
-	}
+        print_help(argv[0]);
+        return -1;
+    }
 
     i = 1;
 #define CHECK_BOUND {\
@@ -98,7 +98,7 @@ int main(int argc, char *argv[])
             p_uart_port = argv[i++];
         } else if (strcmp(argv[i], "--rate") == 0) {
             CHECK_BOUND;
-	        baud_rate = atoi(argv[i++]);
+            baud_rate = atoi(argv[i++]);
         } else if (strcmp(argv[i], "--fw") == 0) {
             CHECK_BOUND;
             fw_file = argv[i++];
@@ -129,7 +129,6 @@ int main(int argc, char *argv[])
             return -2;
         }
     }
-
     /* check arguments */
     if (p_uart_port == NULL || dtb_file == NULL || fw_file == NULL
             || p_part[0] == NULL || eflash_loader_file == NULL
@@ -138,26 +137,25 @@ int main(int argc, char *argv[])
         goto fail2;
     }
 
-	uart_fd = uart_open(p_uart_port, baud_rate);
-	if (uart_fd < 0) {
-		fprintf(stderr, "ERROR: failed to open UART\n");
-		return -2;
-	}
+    uart_fd = uart_open(p_uart_port, baud_rate);
+    if (uart_fd < 0) {
+        fprintf(stderr, "ERROR: failed to open UART\n");
+        return -2;
+    }
 
 #define CHECK_ERROR(ret_code)  {\
     if (0 != (ret_code)) {      \
         goto fail;              \
     }                           \
 }
-	ret_code = hand_shake(uart_fd, baud_rate);
+    ret_code = hand_shake(uart_fd, baud_rate);
     CHECK_ERROR(ret_code);
 
-	/* connection is established now */
-	(void) usleep(20 * 1000);
-	/* read_boot_info */
+    /* connection is established now */
+    (void) usleep(20 * 1000);
+    /* read_boot_info */
     ret_code = request_boot_info(uart_fd, &boot_info);
     CHECK_ERROR(ret_code);
-
     /*
      * Before flashing the images, eflash image has to program to device. eflash is the
      * program executed on device to handle all flash operations, including erase, program,
@@ -169,46 +167,46 @@ int main(int argc, char *argv[])
      * Also note: this boot header might be different from the one generated from
      * efuse_bootheader_cfg.conf, just in case you are curious.
      */
-	/* load_boot_header */
-	(void) usleep(20 * 1000);
+    /* load_boot_header */
+    (void) usleep(20 * 1000);
     ret_code = load_boot_header(uart_fd, eflash_loader_file);
     CHECK_ERROR(ret_code);
 
     if (boot_info.sign != 0) {
-	    /* if signed, load_public_key */
-	    (void) usleep(20 * 1000);
+        /* if signed, load_public_key */
+        (void) usleep(20 * 1000);
         ret_code = load_pub_key(uart_fd);
         CHECK_ERROR(ret_code);
 
-	    /* if signed, load signature */
-	    (void) usleep(20 * 1000);
+        /* if signed, load signature */
+        (void) usleep(20 * 1000);
         ret_code = load_signature(uart_fd);
         CHECK_ERROR(ret_code);
     }
 
     if (boot_info.encrypted) {
-	    /* if encrypted, load AES IV */
-	    (void) usleep(20 * 1000);
+        /* if encrypted, load AES IV */
+        (void) usleep(20 * 1000);
         ret_code = load_aes_iv(uart_fd);
         CHECK_ERROR(ret_code);
     }
 
-	/* load segment header */
+    /* load segment header */
     (void) usleep(20 * 1000);
     ret_code = load_segment_header(uart_fd, eflash_loader_file);
     CHECK_ERROR(ret_code);
 
-	/* load segment data */
+    /* load segment data */
     (void) usleep(20 * 1000);
     ret_code = load_segment_data(uart_fd, eflash_loader_file);
     CHECK_ERROR(ret_code);
 
-	/* check image */
+    /* check image */
     (void) usleep(20 * 1000);
     ret_code = check_image(uart_fd);
     CHECK_ERROR(ret_code);
 
-	/* run image */
+    /* run image */
     (void) usleep(20 * 1000);
     ret_code = run_image(uart_fd);
     CHECK_ERROR(ret_code);
@@ -225,7 +223,7 @@ int main(int argc, char *argv[])
         goto error_p;           \
     }                           \
 }
-    /* TODO: fill the rest */
+
     boot_rom_stage = 0; /* flash stage */
     for (i = 0; i < ARRAY_SIZE(p_file_list) && ret_code == 0; i++) {
         uint8_t *p_buf = NULL;
@@ -233,14 +231,20 @@ int main(int argc, char *argv[])
         uint32_t sz_curr = 0;
 
         if (p_file_list[i].p_file_name == NULL) {
+#ifdef DEBUG
+            printf("WARNING: the file name is empty \n");
+#endif
             break;
         }
+        fprintf(stdout, "flashing *** %s ***\n", p_file_list[i].p_file_name);
         /* read_to_buf, allocate enough memory, and read file into the buf */
         ret_code = read_to_buf(p_file_list[i].p_file_name, &p_buf, &sz_curr);
         CHECK_ERROR_P(ret_code);
 
-        calc_sha256(p_buf, sz_curr, sha_256);
-
+        calc_sha256(p_buf, sz_curr, (uint32_t *)&sha_256[0]);
+#ifdef DEBUG
+        dump_hex("pre-calculate sha256", (uint8_t *)sha_256, sizeof sha_256);
+#endif
         (void) usleep(20 * 1000);
         ret_code = erase_storage(uart_fd, p_file_list[i].dst, sz_curr);
         CHECK_ERROR_P(ret_code);
@@ -254,7 +258,7 @@ int main(int argc, char *argv[])
         CHECK_ERROR_P(ret_code);
 
         (void) usleep(20 * 1000);
-        ret_code = send_sha256(uart_fd, sha_256);
+        ret_code = send_sha256(uart_fd, sha_256, p_file_list[i].dst, sz_curr);
         CHECK_ERROR_P(ret_code);
 
 error_p:
@@ -263,8 +267,13 @@ error_p:
     }
 
     if (ret_code == 0) {
+        printf("------------- sending finish ------------\n");
         ret_code = send_finish(uart_fd);
-        fprintf(stderr, "SUCCEED: flash completed\n");
+        if (ret_code == 0) {
+            fprintf(stderr, "SUCCEED: flash completed\n");
+        } else {
+            fprintf(stderr, "ERROR: re-hand shake fail\n");
+        }
     }
 
 fail:
@@ -272,5 +281,5 @@ fail:
     uart_close(uart_fd);
 
 fail2:
-	return ret_code;
+    return ret_code;
 }

--- a/flash/uart.c
+++ b/flash/uart.c
@@ -22,50 +22,88 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
 #include <sys/time.h>
 #include <termios.h>
-#include <unistd.h>
-#include <fcntl.h>
 
 static int get_baud_rate(uint32_t baud_rate, speed_t *speed)
 {
-	int ret_status = 0;
-	switch(baud_rate) {
-		case 9600:
-			*speed = B9600;
-			break;
-		case 19200:
-			*speed = B19200;
-			break;
-		case 38400:
-			*speed = B38400;
-			break;
-		case 57600:
-			*speed = B57600;
-			break;
-		case 115200:
-			*speed = B115200;
-			break;
-		case 230400:
-			*speed = B230400;
-			break;
-		default:
-			ret_status = -1;
-			break;
-	}
+    int ret_status = 0;
+    switch(baud_rate) {
+        case 9600:
+            *speed = B9600;
+            break;
+        case 19200:
+            *speed = B19200;
+            break;
+        case 38400:
+            *speed = B38400;
+            break;
+        case 57600:
+            *speed = B57600;
+            break;
+        case 115200:
+            *speed = B115200;
+            break;
+        case 230400:
+            *speed = B230400;
+            break;
+        default:
+            ret_status = -1;
+            break;
+    }
 
-	return ret_status;
+    return ret_status;
 }
+
+#if 0
+/*
+ * NOTE: checked on Ubuntu 18.04.6, this code seems not work.
+ * set the baud rate to customer value, e.g. 200000, and check
+ * against with the rate from:
+ *    $stty -F /dev/ttyUSB0
+ * #include <asm/termbits.h>
+ *
+ * directly including the asm/termios.h results in compiler error
+ * due to conflict definition.
+ */
+/*
+ * https://www.downtowndougbrown.com/2013/11/linux-custom-serial-baud-rates/
+ */
+int set_custom_baud_rate(int fd, uint32_t custom_baud) {
+    struct termios2 tio;
+
+    /* Get current settings */
+    if (ioctl(fd, TCGETS2, &tio) < 0) {
+        perror("TCGETS2");
+        return -1;
+    }
+
+    tio.c_cflag &= ~CBAUD;
+    tio.c_cflag |= BOTHER;       /* Allow custom baud */
+    tio.c_ispeed = custom_baud;  /* Input speed */
+    tio.c_ospeed = custom_baud;  /* Output speed */
+
+    /* Apply settings */
+    if (ioctl(fd, TCSETS2, &tio) < 0) {
+        perror("TCSETS2");
+        return -1;
+    }
+
+    return 0;
+}
+#endif
 
 int uart_open(const char *p_uart_port, uint32_t baud_rate)
 {
-	int uart_fd;
+    int uart_fd;
     struct termios options;
-	int ret_status;
-	speed_t speed;
+    int ret_status;
+    speed_t speed;
 
     // Open the UART device file
-    uart_fd = open(p_uart_port, O_RDWR | O_NOCTTY | O_NDELAY);
+    uart_fd = open(p_uart_port, O_RDWR);
     if (uart_fd == -1) {
         fprintf(stderr, "ERROR: Unable to open %s", p_uart_port);
         return -1;
@@ -75,30 +113,16 @@ int uart_open(const char *p_uart_port, uint32_t baud_rate)
     tcgetattr(uart_fd, &options);
 
     // Set baud rate
-	ret_status = get_baud_rate(baud_rate, &speed);
-	if (ret_status < 0) {
-		fprintf(stderr, "ERROR: baud_rate not supported \n");
-#if 0
-		struct termios2 tio;
-		/*
-		 * https://www.downtowndougbrown.com/2013/11/linux-custom-serial-baud-rates/
-		 */
-#include <asm/termios.h>
-		ioctl(fd, TCGETS2, &tio);
-		tio.c_cflag &= ~CBAUD;
-		tio.c_cflag |= BOTHER;
-		tio.c_ispeed = baud_rate;
-		tio.c_ospeed = baud_rate;
-		/* do other miscellaneous setup options with the flags here */
-		ioctl(fd, TCSETS2, &tio);
-#endif
-		uart_fd = -2;
-		goto fail;
-	}
-	else {
-    	cfsetispeed(&options, speed);
-    	cfsetospeed(&options, speed);
-	}
+    ret_status = get_baud_rate(baud_rate, &speed);
+    if (ret_status < 0) {
+        fprintf(stderr, "ERROR: baud_rate not supported \n");
+        uart_fd = -2;
+        goto fail;
+    }
+    else {
+        cfsetispeed(&options, speed);
+        cfsetospeed(&options, speed);
+    }
 
     // 8N1: 8 data bits, no parity, 1 stop bit
     options.c_cflag &= ~PARENB; // No parity
@@ -114,15 +138,12 @@ int uart_open(const char *p_uart_port, uint32_t baud_rate)
     // Apply the settings
     tcsetattr(uart_fd, TCSANOW, &options);
 
-    // Set non-blocking read
-    fcntl(uart_fd, F_SETFL, FNDELAY);
-
 fail:
-	return uart_fd;
+    return uart_fd;
 }
 
 int uart_close(int uart_fd)
 {
-	close(uart_fd);
-	return 0;
+    close(uart_fd);
+    return 0;
 }

--- a/flash/uart.h
+++ b/flash/uart.h
@@ -22,4 +22,9 @@
 
 int uart_open(const char *p_uart_port, uint32_t baud_rate);
 int uart_close(int uart_id);
+
+#if 0
+int set_custom_baud_rate(int fd, uint32_t custom_baud);
+#endif
+
 #endif /* _UART_H */

--- a/inc/packet_comm.h
+++ b/inc/packet_comm.h
@@ -39,7 +39,7 @@ typedef enum {
     COMMAND_ERASE_FLASH = 0x30,
     COMMAND_FLASH_DATA  = 0x31,
     COMMAND_PROG_OK     = 0x3A,
-    COMMAND_SHA_256     = 0x2D
+    COMMAND_SHA_256     = 0x3D
 
 } COMMAND_ID;
 
@@ -110,7 +110,7 @@ typedef struct {
 } segment_header_pkt_t;
 
 /* segment data */
-/* 
+/*
  * BL602_ISP_protocol says: 4096 is the limitation of protocol frame size.
  * If larger, send multiple data to send
  * NOTE: test shows that above is not true.
@@ -199,7 +199,7 @@ typedef struct __attribute__ ((__packed__)){
             uint8_t result_s[2]; /* place holder */
             uint8_t len_lsb_s;
             uint8_t len_msb_s;
-            uint8_t sha256[32];
+            uint32_t sha256[8];
         };
     };
 } bl_resp_t;

--- a/partition/partition_maker.c
+++ b/partition/partition_maker.c
@@ -70,34 +70,35 @@ static bool is_empty_line(char *buf) {
 
 /*
  * https://zlib.net/crc_v3.txt
- * for fun: 
+ * for fun:
  * https://stackoverflow.com/questions/2587766/how-is-a-crc32-checksum-calculated
  */
 static uint32_t calc_crc32(const char *src, uint32_t sz)
 {
     char ch;
-	uint32_t crc = ~0;
-	uint32_t i = 0;
+    uint32_t crc = ~0;
+    uint32_t i = 0;
     uint32_t j = 0;
     uint32_t b = 0;
-	
+
     printf("crc = 0x%x\n", crc);
-	for(i = 0; i < sz; i++) {
-		ch = src[i];
-		for(j = 0; j < 8; j++) {
-			b = (ch ^ crc) & 1;
-			crc >>= 1;
-			if (b) {
+    for(i = 0; i < sz; i++) {
+        ch = src[i];
+        for(j = 0; j < 8; j++) {
+            b = (ch ^ crc) & 1;
+            crc >>= 1;
+            if (b) {
                 crc=crc^0xEDB88320;
             }
-			ch >>= 1;
-		}
-	}
+            ch >>= 1;
+        }
+    }
 
     printf("crc = %x\n", ~crc);
-	return ~crc;
+    return ~crc;
 }
-/* 
+
+/*
  * The customized parser to handle the partition configuration
  * in toml format. Intended to fullfill the need without dependency.
  */
@@ -196,13 +197,13 @@ static int parse_partition_cfg(const char *p_cfg_file,
 
     p_partition->pt_table.magic = BFLB_PT_MAGIC_CODE;
     p_partition->pt_table.entry_cnt = idx + 1;
-    /* 
+    /*
      * TODO: what is the crc32 in p_partition->pt_table.crc32?
      * unused?
      */
     p_partition->crc32 = calc_crc32((char *)&p_partition->pt_entries,
             sizeof p_partition->pt_entries);
-    
+
 fail:
     fclose(p_file);
     return ret_code;


### PR DESCRIPTION
The focus of this change is to iron out the issues during the flash
test. Here are the issues addressed:

1./ Wrong fields when parsing efuse_boot_header configure because
of 'strncmp' matching. Parse the configuration lines into token and
value pointer with spaces trimmed, then use 'strcmp'.

2./ Issues with accessing device port. Use the default block mode.

3./ CRC missing in erase packet.

4./ Wrong packet length in the flash data packet. Should include
the length of the targeted address.

5./ SHA256 packet has incomplete values.

Other than that, the following improvements:

a./ Rewrite hand-shake code with dynamic memory to hold the number
of '0x55' in the stream.

b./ Move redudant debug prints under #ifdef DEBUG.

c./ Expose dump_hex so that other file can use it.

d./ replace '\t' with spaces.
